### PR TITLE
Fix ABS_MSG output length for AEAD mode

### DIFF
--- a/rtl/ascon_core.sv
+++ b/rtl/ascon_core.sv
@@ -138,6 +138,10 @@ module ascon_core (
 
   logic [LANES-1:0][W64-1:0][CCW-1:0] asconp_o;
 
+  //change 1: to fix the problem bdo cipher output not equal to the plaintext
+  logic [CCW:0] valid_mask;
+  assign valid_mask = (CCW==32) ? {{8{bdi_valid[3]}}, {8{bdi_valid[2]}}, {8{bdi_valid[1]}}, {8{bdi_valid[0]}}}: {{8{bdi_valid[7]}}, {8{bdi_valid[6]}}, {8{bdi_valid[5]}}, {8{bdi_valid[4]}}, {8{bdi_valid[3]}}, {8{bdi_valid[2]}}, {8{bdi_valid[1]}}, {8{bdi_valid[0]}}};
+
   // Instantiation of Ascon-p permutation
   asconp asconp_i (
     .round_cnt(round_cnt),
@@ -188,7 +192,8 @@ module ascon_core (
         if (mode_r == M_AEAD128_ENC || mode_hash_xof) begin
           bdi_pad = pad(bdi, bdi_valid);
           state_nx = state_slice ^ bdi_pad;
-          bdo = state_nx;
+        //changed2
+          bdo = valid_mask&state_nx;
         end else if (mode_r == M_AEAD128_DEC) begin
           bdi_pad = pad2(bdi, state_slice, bdi_valid);
           state_nx = bdi_pad;


### PR DESCRIPTION
**Problem:**  : In the ABS_MSG phase of AEAD mode, if the plaintext length is less than 128 bits, the current implementation outputs 128 bytes of ciphertext. According to the ASCON specification, the ciphertext should match the plaintext length. Clearly, the ciphertext generates part of the state-S.

**Test Vectors:**  
Count = 35
Key = 000102030405060708090A0B0C0D0E0F
Nonce = 101112131415161718191A1B1C1D1E1F
PT = 20
AD = 30
CT = 962B8016836C75A7D86866588CA245D886
![Test Waveform]<img width="1061" height="326" alt="image" src="https://github.com/user-attachments/assets/77b000a5-bc3a-43d8-be66-31478d733444" />

**Solution:**   Add one variable called valid_mask to ensure the output length matches the plaintext.

**Notes:**   However, I am still relatively new to Verilog and ASCON, so I kindly request your verification on whether this approach represents the optimal solution within the core. Thank you.