### PR TITLE
fix: gate bdi_ready and bdo_valid on bdo_ready in ABS_MSG for AEAD

### DIFF
--- a/rtl/ascon_core.sv
+++ b/rtl/ascon_core.sv
@@ -219,8 +219,8 @@ module ascon_core (
           state_slice_nx = bdi_pad;
           bdo = mask(state_slice ^ state_slice_nx, bdi_valid);
         end
-        bdi_ready = 'd1;
-        bdo_valid = mode_enc_dec ? 'd1 : 'd0;
+        bdi_ready = mode_enc_dec ? bdo_ready : 'd1;
+        bdo_valid = (mode_enc_dec && (bdi_valid != 'd0)) ? 'd1 : 'd0;
         bdo_type  = mode_enc_dec ? D_MSG : D_INVALID;
         bdo_eot   = mode_enc_dec ? bdi_eot : 'd0;
         if (mode_q == M_HASH256) bdo = 'd0;

--- a/test.py
+++ b/test.py
@@ -16,7 +16,8 @@ RUNS = range(0, 10)
 CCW = 32
 # CCW = 64
 CCWD8 = CCW // 8
-STALLS = 0
+STALL_INPUT = 0
+STALL_OUTPUT = 0
 
 
 # Needs to match "mode_t" in "rtl/config.sv"
@@ -78,6 +79,10 @@ async def send_data(dut, data_in, bdi_type, bdo_ready, bdi_eoi):
     d = 0
     data_out = []
     while d < dlen:
+        if STALL_INPUT:
+            for _ in range(random.randint(1, 10)):
+                await clear_bdi(dut)
+                await RisingEdge(dut.clk)
         bdi = 0
         bdi_valid = 0
         for dd in range(d, min(d + CCWD8, dlen)):
@@ -89,8 +94,6 @@ async def send_data(dut, data_in, bdi_type, bdo_ready, bdi_eoi):
         dut.bdi_eot.value = d + CCWD8 >= dlen
         dut.bdi_eoi.value = d + CCWD8 >= dlen and bdi_eoi
         dut.bdo_ready.value = bdo_ready
-        if STALLS and (random.randint(0, 10) != 0):
-            await clear_bdi(dut)
         await RisingEdge(dut.clk)
         if int(dut.bdi_valid.value) and int(dut.bdi_ready.value):
             if VERBOSE >= 3:
@@ -130,11 +133,13 @@ async def receive_data(dut, type, len=16, bdo_eoo=0):
     d = 0
     data_out = []
     while d < len:
+        if STALL_OUTPUT:
+            for _ in range(random.randint(1, 10)):
+                dut.bdo_ready.value = 0
+                dut.bdo_eoo.value = 0
+                await RisingEdge(dut.clk)
         dut.bdo_ready.value = 1
         dut.bdo_eoo.value = (d + CCWD8 >= len) & bdo_eoo
-        if STALLS and (random.randint(0, 10) != 0):
-            dut.bdo_ready.value = 0
-            dut.bdo_eoo.value = 0
         await RisingEdge(dut.clk)
         if int(dut.bdo_ready.value) and int(dut.bdo_valid.value) and (int(dut.bdo_type.value) == type):
             if VERBOSE >= 3:
@@ -221,7 +226,6 @@ def corrupt(data):
 
 @cocotb.test()
 async def test_enc(dut):
-
     # init test
     random.seed(31415)
     mode = Mode.M_AEAD128_ENC
@@ -280,9 +284,31 @@ async def test_enc(dut):
             # check tag
             for i in range(len(tag)):
                 assert tag_hw[i] == tag[i], "tag mismatch"
-            
+
             await cycle_task.complete
             log(dut, verbose=1, dashes=1)
+
+
+@cocotb.test()
+async def test_enc_backpressure(dut):
+    global STALL_OUTPUT
+    stall_output = STALL_OUTPUT
+    STALL_OUTPUT = 1
+    try:
+        await test_enc.func(dut)
+    finally:
+        STALL_OUTPUT = stall_output
+
+
+@cocotb.test()
+async def test_enc_rare_input(dut):
+    global STALL_INPUT
+    stall_input = STALL_INPUT
+    STALL_INPUT = 1
+    try:
+        await test_enc.func(dut)
+    finally:
+        STALL_INPUT = stall_input
 
 
 # ,------.                                       ,--.
@@ -295,7 +321,6 @@ async def test_enc(dut):
 
 @cocotb.test()
 async def test_dec(dut):
-
     # init test
     random.seed(31415)
     mode = Mode.M_AEAD128_DEC
@@ -358,6 +383,28 @@ async def test_dec(dut):
 
             await cycle_task.complete
             log(dut, verbose=1, dashes=1)
+
+
+@cocotb.test()
+async def test_dec_backpressure(dut):
+    global STALL_OUTPUT
+    stall_output = STALL_OUTPUT
+    STALL_OUTPUT = 1
+    try:
+        await test_dec.func(dut)
+    finally:
+        STALL_OUTPUT = stall_output
+
+
+@cocotb.test()
+async def test_dec_rare_input(dut):
+    global STALL_INPUT
+    stall_input = STALL_INPUT
+    STALL_INPUT = 1
+    try:
+        await test_dec.func(dut)
+    finally:
+        STALL_INPUT = stall_input
 
 
 # ,------.                                       ,--.      ,------.       ,--.,--.


### PR DESCRIPTION
gate bdi_ready and bdo_valid on bdo_ready in ABS_MSG for AEAD modes

Bug:
In M_AEAD128_ENC and M_AEAD128_DEC, bdo is purely combinatorial from
bdi during ABS_MSG.

When downstream holds bdo_ready=0, bdo
changes every cycle as the upstream presents new bdi data, violating
the valid-until-ready protocol: unaccepted output beat
must remain valid and stable until accepted.

The existing abs_msg signal already correctly requires bdo_ready before
advancing internal state, but bdi_ready was always 1 in ABS_MSG.
The upstream keeps changing bdi even though ASCON cannot 
process the beat. This causes bdo to drop when not accepted.

Fix:
- bdi_ready = mode_enc_dec ? bdo_ready : 'd1
  Input is only accepted when the output can also be accepted, ensuring
  bdi stays stable during backpressure and bdo stays stable with it.

- bdo_valid = (mode_enc_dec && (bdi_valid != 'd0)) ? 'd1 : 'd0
  bdo_valid is only asserted when there is genuinely valid input data,
  not unconditionally throughout ABS_MSG. This prevents spurious valid
  assertions when bdi_valid is zero.

Modes affected: M_AEAD128_ENC, M_AEAD128_DEC

Testbenches:
- Changed STALL to STALL_INPUT and STALL_OUTPUT
- Stalling stalls for multiple cycles
- Added test were input stalls multiple cycles on encryption
- Added test were input stalls multiple cycles on decrytpion
- Added test with "rare" input on encryption
- Added test with "rare" input on  decryption
 

Unaffected modes:
M_HASH256, M_XOF128, M_CXOF128: bdo_valid was already 0 throughout
ABS_MSG in these modes. Output is produced in SQZ_HASH where bdo comes
from registered state_slice and is already stable under backpressure.
bdi_ready remains unconditionally 1 for these modes.